### PR TITLE
Add --with-gc=OPT configure flag, and more

### DIFF
--- a/GNUmakefile.in
+++ b/GNUmakefile.in
@@ -21,6 +21,9 @@ ABI_CFLAGS = @ABI_CFLAGS@
 HPCGAP = @HPCGAP@
 ADDGUARDS2 = @ADDGUARDS2@
 
+# garbage collector source files
+GC_SOURCES = @GC_SOURCES@
+
 # compatibility mode
 COMPAT_MODE = @COMPAT_MODE@
 GAPARCH = @GAPARCH@

--- a/Makefile.rules
+++ b/Makefile.rules
@@ -100,12 +100,7 @@ SOURCES += src/vecgf2.c
 SOURCES += src/vector.c
 SOURCES += src/weakptr.c
 
-# TODO: Change the following to check for a new USE_BOEHM flag
-ifeq ($(HPCGAP),yes)
-  SOURCES += src/boehm_gc.c
-else
-  SOURCES += src/gasman.c
-endif
+SOURCES += $(GC_SOURCES)
 
 ifeq ($(GAPMPI),yes)
   SOURCES += src/hpc/gapmpi.c

--- a/configure.ac
+++ b/configure.ac
@@ -183,18 +183,53 @@ dnl If on, build an HPCGAP executable instead of standard GAP.
 dnl
 AC_ARG_ENABLE([hpcgap],
     [AS_HELP_STRING([--enable-hpcgap], [enable HPC-GAP])],
-    [AC_DEFINE([HPCGAP], [1], [define if building HPC-GAP])],
-    [enable_hpcgap=no]
-    )
+    [],
+    [enable_hpcgap=no])
 AC_MSG_CHECKING([whether to enable HPC-GAP])
 AC_MSG_RESULT([$enable_hpcgap])
 
 AC_SUBST([HPCGAP], [$enable_hpcgap])
 AS_IF([test "x$enable_hpcgap" = xyes],
     [
-    # HACK (see issue #9)
+    AC_DEFINE([HPCGAP], [1], [define if building HPC-GAP])
+
+    # HACK, see https://github.com/fingolfin/gap/issues/9
     AC_DEFINE([MAX_GC_THREADS], [4], [maximum number of GC threads])
     ])
+
+dnl
+dnl User setting: garbage collector to use
+dnl
+AC_ARG_WITH([gc],
+    [AS_HELP_STRING([--with-gc@<:@=default|gasman|boehm|julia@:>@],
+      [specify which garbage collector to use (default: gasman; for HPC-GAP: boehm)])],
+    [],
+    [with_gc=default])
+AC_MSG_CHECKING([which garbage collector to use])
+AS_IF([test "x$with_gc" = xyes], [with_gc=default])
+AS_IF([test "x$with_gc" = xdefault],
+    [
+    AS_IF([test "x$enable_hpcgap" = xyes], [with_gc=boehm], [with_gc=gasman])
+    ])
+AS_CASE([$with_gc],
+    [none|no],  [AC_MSG_ERROR([cannot run GAP without a garbage collector])],
+    [boehm],    [AS_IF([test "x$enable_hpcgap" = xno],
+                    [AC_MSG_ERROR([Boehm GC can only be used with HPC-GAP])])
+                 AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
+                 AC_DEFINE([BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
+                 AC_DEFINE([ALT_GC],    [1], [Use alternate garbage collector])
+                 ],
+    [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],
+                    [AC_MSG_ERROR([GASMAN can not be used with HPC-GAP])])
+                 AC_SUBST([GC_SOURCES], [src/gasman.c])
+                 AC_DEFINE([USE_GASMAN],    [1], [define as 1 if GASMAN is used])],
+    [julia],    [AC_SUBST([GC_SOURCES], [src/julia_gc.c])
+                 AC_DEFINE([USE_JULIA_GC],  [1], [define as 1 if Julia's GC is used])
+                 AC_DEFINE([ALT_GC],        [1], [Use alternate garbage collector])
+                 ],
+    [*],        [AC_MSG_ERROR([Invalid gc method '$with_gc', use default|none|gasman|boehm|julia])],
+    )
+AC_MSG_RESULT([$with_gc])
 
 dnl
 dnl User setting: Debug mode (off by default)
@@ -401,9 +436,11 @@ AS_IF([test "x$enable_hpcgap" = xyes],
 
   ATOMIC_OPS_CFLAGS=$LIBATOMIC_OPS_CPPFLAGS
   ATOMIC_OPS_LIBS=$LIBATOMIC_OPS_LDFLAGS
+  ]
+)
 
-  AC_DEFINE([BOEHM_GC], [1], [Use Boehm garbage collector])
-  AC_DEFINE([ALT_GC], [1], [Use alternate garbage collector])
+AS_IF([test "x$with_gc" = xboehm],
+  [
   BUILD_BOEHM_GC=yes
   BOEHM_GC_CPPFLAGS='-I${abs_builddir}/extern/install/gc/include'
   BOEHM_GC_LDFLAGS='${abs_builddir}/extern/install/gc/lib/libgc.la'

--- a/configure.ac
+++ b/configure.ac
@@ -216,7 +216,7 @@ AS_CASE([$with_gc],
     [boehm],    [AS_IF([test "x$enable_hpcgap" = xno],
                     [AC_MSG_ERROR([Boehm GC can only be used with HPC-GAP])])
                  AC_SUBST([GC_SOURCES], [src/boehm_gc.c])
-                 AC_DEFINE([BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
+                 AC_DEFINE([USE_BOEHM_GC],  [1], [define as 1 if Boehm GC is used])
                  AC_DEFINE([ALT_GC],    [1], [Use alternate garbage collector])
                  ],
     [gasman],   [AS_IF([test "x$enable_hpcgap" = xyes],

--- a/src/boehm_gc.c
+++ b/src/boehm_gc.c
@@ -22,7 +22,7 @@
 #include <src/vars.h>
 #endif
 
-#ifndef BOEHM_GC
+#ifndef USE_BOEHM_GC
 #error This file can only be used when the Boehm GC collector is enabled
 #endif
 

--- a/src/gap.c
+++ b/src/gap.c
@@ -3030,7 +3030,7 @@ void RecordLoadedModule (
 **  general    `InitLibrary'  will  create    all objects    and  then  calls
 **  `PostRestore'.  This function is only used when restoring.
 */
-#ifndef ALT_GC
+#ifdef USE_GASMAN
 extern TNumMarkFuncBags TabMarkFuncBags [ 256 ];
 #endif
 
@@ -3053,7 +3053,7 @@ void InitializeGap (
     InitBags( SyAllocBags, SyStorMin,
               0, (Bag*)(((UInt)pargc/C_STACK_ALIGN)*C_STACK_ALIGN), C_STACK_ALIGN,
               SyAbortBags );
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
     InitMsgsFuncBags( SyMsgsBags );
 #endif
 
@@ -3136,7 +3136,7 @@ void InitializeGap (
     }
 #endif
 
-#ifndef ALT_GC
+#ifdef USE_GASMAN
     /* and now for a special hack                                          */
     for ( i = LAST_CONSTANT_TNUM+1; i <= LAST_REAL_TNUM; i++ ) {
       if (TabMarkFuncBags[i + COPYING] == MarkAllSubBagsDefault)
@@ -3178,7 +3178,7 @@ void InitializeGap (
 
     /* otherwise call library initialisation                               */
     else {
-#       if !defined(ALT_GC)
+#       ifdef USE_GASMAN
             WarnInitGlobalBag = 1;
 #       endif
         CheckAllHandlers();
@@ -3200,7 +3200,7 @@ void InitializeGap (
                 }
             }
         }
-#if     !defined(ALT_GC)
+#       ifdef USE_GASMAN
             WarnInitGlobalBag = 0;
 #       endif
     }

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -854,7 +854,7 @@ static inline void MarkBag( Bag bag ) {}
 **  "IS_WEAK_DEAD_BAG". Which should  always be   checked before copying   or
 **  using such an identifier.
 */
-#if !defined(BOEHM_GC)
+#if !defined(USE_BOEHM_GC)
 extern void MarkBagWeakly( Bag bag );
 #endif
 

--- a/src/gasman.h
+++ b/src/gasman.h
@@ -88,7 +88,7 @@ typedef struct {
     uint16_t reserved : 16;
     uint32_t size : 32;
 #endif
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
     Bag link;
 #endif
 } BagHeader;
@@ -726,7 +726,7 @@ Bag MakeBagReadOnly(Bag bag);
 **  34+3016 is the  number  of bags allocated  between  the last two  garbage
 **  collections, using 978 KByte and the other two numbers are as above.
 */
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 typedef void            (* TNumMsgsFuncBags) (
             UInt                full,
             UInt                phase,
@@ -826,7 +826,7 @@ extern void MarkAllSubBagsDefault ( Bag );
 **  identifier.
 
 */
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 extern void MarkBag( Bag bag );
 #else
 static inline void MarkBag( Bag bag ) {}
@@ -874,7 +874,7 @@ extern void MarkArrayOfBags(const Bag array[], UInt count);
 *F
 */
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 extern  Bag *                   MptrBags;
 extern  Bag *                   OldBags;
@@ -885,7 +885,7 @@ extern  Bag *                   AllocBags;
                                 (bag) < (Bag)OldBags  &&              \
                                 (((UInt)*bag) & (sizeof(Bag)-1)) == 1)
 
-#else
+#elif defined(USE_BOEHM_GC)
 
 #define IS_WEAK_DEAD_BAG(bag) (!(bag))
 #define REGISTER_WP(loc, obj) \
@@ -933,7 +933,7 @@ extern  void            InitSweepFuncBags (
 **
 *V  GlobalBags  . . . . . . . . . . . . . . . . . . . . . list of global bags
 */
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 #ifndef NR_GLOBAL_BAGS
 #define NR_GLOBAL_BAGS  20000L
@@ -979,7 +979,7 @@ extern void InitGlobalBag (
             Bag *               addr,
             const Char *        cookie );
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 extern Int WarnInitGlobalBag;
 

--- a/src/hpc/thread.c
+++ b/src/hpc/thread.c
@@ -19,7 +19,7 @@
 #include <sys/mman.h>
 #include <unistd.h>
 
-#ifdef ALT_GC
+#ifdef USE_BOEHM_GC
 # ifdef HPCGAP
 #  define GC_THREADS
 # endif

--- a/src/hpc/threadapi.c
+++ b/src/hpc/threadapi.c
@@ -919,7 +919,7 @@ Obj TypeRegion(Obj obj)
     return TYPE_REGION;
 }
 
-#ifndef ALT_GC
+#ifdef USE_GASMAN
 static void MarkSemaphoreBag(Bag);
 static void MarkChannelBag(Bag);
 static void MarkBarrierBag(Bag);
@@ -951,7 +951,7 @@ void DestroyThreadAPIState(void)
 {
 }
 
-#ifndef ALT_GC
+#ifdef USE_GASMAN
 static void MarkSemaphoreBag(Bag bag)
 {
     Semaphore * sem = (Semaphore *)(PTR_BAG(bag));
@@ -2765,7 +2765,7 @@ static Int InitKernel(StructInitInfo * module)
     InitMarkFuncBags(T_THREAD, MarkNoSubBags);
     InitMarkFuncBags(T_MONITOR, MarkNoSubBags);
     InitMarkFuncBags(T_REGION, MarkAllSubBags);
-#ifndef ALT_GC
+#ifdef USE_GASMAN
     InitMarkFuncBags(T_SEMAPHORE, MarkSemaphoreBag);
     InitMarkFuncBags(T_CHANNEL, MarkChannelBag);
     InitMarkFuncBags(T_BARRIER, MarkBarrierBag);

--- a/src/hpc/threadapi.h
+++ b/src/hpc/threadapi.h
@@ -49,7 +49,4 @@ void UnlockMonitors(UInt count, Monitor **monitors);
 
 void InitSignals(void);
 
-void InitThreadAPIState(void);
-void DestroyThreadAPIState(void);
-
 #endif // GAP_THREADAPI_H

--- a/src/hpc/traverse.c
+++ b/src/hpc/traverse.c
@@ -13,7 +13,7 @@
 #include <src/hpc/guards.h>
 #include <src/hpc/thread.h>
 
-#ifdef ALT_GC
+#ifdef USE_BOEHM_GC
 # ifdef HPCGAP
 #  define GC_THREADS
 # endif

--- a/src/rational.c
+++ b/src/rational.c
@@ -885,7 +885,7 @@ static Int InitKernel (
      * more space-efficient for the Boehm GC and does not incur a
      * speed penalty.
      */
-#ifndef ALT_GC
+#ifdef USE_GASMAN
     InitMarkFuncBags( T_RAT, MarkTwoSubBags );
 #else
     InitMarkFuncBags( T_RAT, MarkAllSubBags );

--- a/src/saveload.c
+++ b/src/saveload.c
@@ -42,7 +42,7 @@ static UInt1* LBPointer;
 static UInt1* LBEnd;
 static Obj userHomeExpand;
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 static Int OpenForSave( Obj fname ) 
 {
@@ -327,7 +327,7 @@ void LoadString ( Obj string )
 
 void SaveSubObj( Obj subobj )
 {
-#ifdef ALT_GC
+#ifndef USE_GASMAN
   // FIXME: HACK
   assert(0);
 #else
@@ -352,7 +352,7 @@ void SaveSubObj( Obj subobj )
 
 Obj LoadSubObj( void )
 {
-#ifdef ALT_GC
+#ifndef USE_GASMAN
   // FIXME: HACK
   assert(0);
 #else
@@ -400,7 +400,7 @@ ObjFunc LoadHandler( void )
 **  Bag level saving routines
 */
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 static void SaveBagData (Bag bag )
 {
@@ -447,7 +447,7 @@ static void LoadBagData ( void )
 **
 */
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 static void WriteEndiannessMarker( void )
 {
@@ -561,7 +561,7 @@ Obj FuncFindBag( Obj self, Obj minsize, Obj maxsize, Obj tnum )
 **  The return value is either True or Fail
 */
 
-#if !defined(ALT_GC)
+#ifdef USE_GASMAN
 
 static UInt NextSaveIndex = 1;
 
@@ -623,8 +623,8 @@ static void WriteSaveHeader( void )
 
 Obj SaveWorkspace( Obj fname )
 {
-#ifdef ALT_GC
-  Pr("SaveWorkspace is not currently supported when Boehm GC is in use",0,0);
+#ifndef USE_GASMAN
+  Pr("SaveWorkspace is only supported when GASMAN is in use",0,0);
   return Fail;
 
 #else
@@ -703,8 +703,8 @@ Obj FuncSaveWorkspace(Obj self, Obj filename )
 
 void LoadWorkspace( Char * fname )
 {
-#ifdef ALT_GC
-  Pr("LoadWorkspace is not currently supported when Boehm GC is in use",0,0);
+#ifndef USE_GASMAN
+  Pr("LoadWorkspace is only supported when GASMAN is in use",0,0);
   return;
 
 #else

--- a/src/system.h
+++ b/src/system.h
@@ -1065,24 +1065,12 @@ extern void SySleep( UInt secs );
 extern void SyUSleep( UInt msecs );
 
 /****************************************************************************
-**
-*F  getOptionCount ( <key> ) . number of times a command line option was used
-*F  getOptionArg ( <key>, <which> ) get arguments used on <which>'th occurrence
-*F                             of <key> as a command line option NULL if none
-**
-*/
-
-extern Int getOptionCount (Char key);
-extern Char *getOptionArg(Char key, UInt which);
-
-/****************************************************************************
  **
  *F    sySetjmp( <jump buffer> )
  *F    syLongjmp( <jump buffer>, <value>)
  ** 
  **   macros and functions, defining our selected longjump mechanism
  */
-
 
 #if defined(HAVE_SIGSETJMP)
 #define sySetjmp( buff ) (sigsetjmp( (buff), 0))

--- a/src/weakptr.h
+++ b/src/weakptr.h
@@ -34,10 +34,5 @@
 */
 StructInitInfo * InitInfoWeakPtr ( void );
 
-#ifdef ALT_GC
-void RegisterWeakReference(Bag *bag);
-void UnregisterWeakReference(Bag *bag);
-#endif
-
 
 #endif // GAP_WEAKPTR_H


### PR DESCRIPTION
This improves the build system by adding a --with-gc=OPT option, plus some other GC related changes.

BTW, the following code in `src/hpc/thread.c` likely also needs to be adjusted:
```C
#ifndef DISABLE_GC
void AddGCRoots(void)
{
    void * p = ActiveGAPState();
    GC_add_roots(p, (char *)p + sizeof(GAPState));
}

void RemoveGCRoots(void)
{
    void * p = ActiveGAPState();
#if defined(__CYGWIN__) || defined(__CYGWIN32__)
    memset(p, '\0', sizeof(GAPState));
#else
    GC_remove_roots(p, (char *)p + sizeof(GAPState));
#endif
}
#endif /* DISABLE_GC */
```