### PR TITLE
Remove unused functions, avoid old-style function definitions

### DIFF
--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -101,35 +101,6 @@ static inline int lt_ptr(void *a, void *b)
     return (uintptr_t) a < (uintptr_t) b;
 }
 
-static inline int gt_ptr(void *a, void *b)
-{
-    return (uintptr_t) a > (uintptr_t) b;
-}
-
-static inline void *max_ptr(void *a, void *b)
-{
-    if ((uintptr_t) a > (uintptr_t) b)
-        return a;
-    else
-        return b;
-}
-
-static inline void *min_ptr(void *a, void *b)
-{
-    if ((uintptr_t) a < (uintptr_t) b)
-        return a;
-    else
-        return b;
-}
-
-/* align pointer to full word if mis-aligned */
-static inline void *align_ptr(void *p)
-{
-    uintptr_t u = (uintptr_t) p;
-    u &= ~(sizeof(p)-1);
-    return (void *)u;
-}
-
 typedef struct treap_t {
   struct treap_t *left, *right;
   size_t prio;

--- a/src/julia_gc.c
+++ b/src/julia_gc.c
@@ -139,7 +139,7 @@ typedef struct treap_t {
 
 static treap_t *treap_free_list;
 
-treap_t *alloc_treap() {
+treap_t *alloc_treap(void) {
   treap_t *result;
   if (treap_free_list) {
     result = treap_free_list;
@@ -285,7 +285,7 @@ static int treap_delete(treap_t **treap, void *addr)
 
 static uint64_t xorshift_rng_state = 1;
 
-static uint64_t xorshift_rng()
+static uint64_t xorshift_rng(void)
 {
     uint64_t x = xorshift_rng_state;
     x = x ^ (x >> 12);
@@ -470,7 +470,7 @@ void            RetypeBag (
     header->type = new_type;
 }
 
-static inline Bag AllocateMasterPointer() {
+static inline Bag AllocateMasterPointer(void) {
   // HOOK: Allocate memory for the master pointer.
   // Master pointers require one word of memory.
   void *result = (void *) jl_gc_alloc(JuliaTLS,


### PR DESCRIPTION
This fixes some compiler warnings